### PR TITLE
Add slash to path if it is missing in request.

### DIFF
--- a/src/request.toit
+++ b/src/request.toit
@@ -34,8 +34,9 @@ class Request:
     return null
 
   send -> Response:
+    slash := (path.starts_with "/") ? "" : "/"
     body_writer := connection_.send_headers
-      "$method $path $version\r\n"
+      "$method $slash$path $version\r\n"
       headers
     if body:
       while data := body.read:


### PR DESCRIPTION
RFC7230 only allows absolute paths for GET, POST, etc.
so this is helpful.