### PR TITLE
Rationalize the methods on Client.

### DIFF
--- a/src/client.toit
+++ b/src/client.toit
@@ -339,7 +339,9 @@ class Client:
 
     return post_ data parsed --headers=headers --content_type=content_type --follow_redirects=follow_redirects
 
-  parse_ uri/string? host/string? port/int? path/string? use_tls/bool? --web_socket/bool? -> ParsedUri_:
+  /// Rather than verbose named args, this private method has the args in the
+  /// order in which they appear in a URI.
+  parse_ uri/string? host/string? port/int? path/string? use_tls/bool? --web_socket/bool -> ParsedUri_:
     default_scheme := (use_tls == null ? use_tls_by_default_ : use_tls)
         ? (web_socket ? "wss" : "https")
         : (web_socket ? "ws" : "http")
@@ -347,7 +349,7 @@ class Client:
       if host or port or path: throw "Cannot combine --uri with host, port, or path arguments"
       result := ParsedUri_.parse_ uri --default_scheme=default_scheme
       // If the user uses the use_tls flag, but supplies a URI that parses to
-      // something else we throw rather than just guessing what they actually
+      // something else, we throw rather than just guessing what they actually
       // wanted.  A redirect can still switch the Client between TLS and non-TLS.
       if use_tls and (result.scheme == "http" or result.scheme == "ws"): throw "Requested TLS, but URI specifies non-TLS"
       if use_tls == false and (result.scheme == "https" or result.scheme == "wss"): throw "Requested no TLS, but URI specifies TLS"

--- a/src/web_socket.toit
+++ b/src/web_socket.toit
@@ -204,10 +204,9 @@ class WebSocket:
     headers.add "Sec-WebSocket-Version" "13"
     return nonce
 
-  static check_client_upgrade_response_ response/Response nonce/string [on_error] -> none:
+  static check_client_upgrade_response_ response/Response nonce/string -> none:
     if response.status_code != STATUS_SWITCHING_PROTOCOLS:
-      on_error.call response
-      throw response.stringify
+      throw "WebSocket upgrade failed with $response.status_code $response.status_message"
     upgrade_header := response.headers.single "Upgrade"
     connection_header := response.headers.single "Connection"
     if not upgrade_header

--- a/tests/parse_url.toit
+++ b/tests/parse_url.toit
@@ -6,30 +6,30 @@ import http
 import expect show *
 
 main:
-  parts := http.ParsedUri_.parse "https://www.youtube.com/watch?v=2HJxya0CWco#t=0m6s"
+  parts := http.ParsedUri_.parse_ "https://www.youtube.com/watch?v=2HJxya0CWco#t=0m6s"
   expect_equals "https"                parts.scheme
   expect_equals "www.youtube.com"      parts.host
   expect_equals 443                    parts.port
   expect_equals "/watch?v=2HJxya0CWco" parts.path
   expect_equals "t=0m6s"               parts.fragment
 
-  http.ParsedUri_.parse                                   "https://www.youtube.com/watch?v=2HJxya0CWco"
-  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse "https://www.youtube.com-/watch?v=2HJxya0CWco"
-  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse "https://www.youtube.-com/watch?v=2HJxya0CWco"
-  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse "https://www.youtube-.com/watch?v=2HJxya0CWco"
-  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse "https://www.-youtube.com/watch?v=2HJxya0CWco"
-  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse "https://www-.youtube.com/watch?v=2HJxya0CWco"
-  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse "https://-www.youtube.com/watch?v=2HJxya0CWco"
-  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse "https://.www.youtube.com/watch?v=2HJxya0CWco"
-  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse "https://www..youtube.com/watch?v=2HJxya0CWco"
-  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse "https://www..y'utube.com/watch?v=2HJxya0CWco"
-  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse "https://www..yøutube.com/watch?v=2HJxya0CWco"
+  http.ParsedUri_.parse_                                   "https://www.youtube.com/watch?v=2HJxya0CWco"
+  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse_ "https://www.youtube.com-/watch?v=2HJxya0CWco"
+  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse_ "https://www.youtube.-com/watch?v=2HJxya0CWco"
+  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse_ "https://www.youtube-.com/watch?v=2HJxya0CWco"
+  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse_ "https://www.-youtube.com/watch?v=2HJxya0CWco"
+  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse_ "https://www-.youtube.com/watch?v=2HJxya0CWco"
+  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse_ "https://-www.youtube.com/watch?v=2HJxya0CWco"
+  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse_ "https://.www.youtube.com/watch?v=2HJxya0CWco"
+  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse_ "https://www..youtube.com/watch?v=2HJxya0CWco"
+  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse_ "https://www..y'utube.com/watch?v=2HJxya0CWco"
+  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse_ "https://www..yøutube.com/watch?v=2HJxya0CWco"
 
-  expect_throw "Unknown scheme: fisk": http.ParsedUri_.parse "fisk://fishing.net/"
-  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse "/a/relative/url"
-  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse "http:/127.0.0.1/path"
+  expect_throw "Unknown scheme: fisk": http.ParsedUri_.parse_ "fisk://fishing.net/"
+  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse_ "/a/relative/url"
+  expect_throw "URI_PARSING_ERROR": http.ParsedUri_.parse_ "http:/127.0.0.1/path"
 
-  parts = http.ParsedUri_.parse "wss://api.example.com./end-point"
+  parts = http.ParsedUri_.parse_ "wss://api.example.com./end-point"
   expect_equals "wss"               parts.scheme
   expect_equals "api.example.com."  parts.host
   expect_equals 443                 parts.port
@@ -37,12 +37,12 @@ main:
   expect_equals null                parts.fragment
   expect                            parts.use_tls
 
-  parts = http.ParsedUri_.parse "WSS://api.example.com./end-point"
+  parts = http.ParsedUri_.parse_ "WSS://api.example.com./end-point"
   expect_equals "wss"               parts.scheme
-  parts = http.ParsedUri_.parse "htTPs://api.example.com./end-point"
+  parts = http.ParsedUri_.parse_ "htTPs://api.example.com./end-point"
   expect_equals "https"               parts.scheme
 
-  parts = http.ParsedUri_.parse "www.yahoo.com"
+  parts = http.ParsedUri_.parse_ "www.yahoo.com" --default_scheme="https"
   expect_equals "https"         parts.scheme
   expect_equals "www.yahoo.com" parts.host
   expect_equals 443             parts.port
@@ -50,7 +50,7 @@ main:
   expect_equals null            parts.fragment
   expect                        parts.use_tls
 
-  parts = http.ParsedUri_.parse "localhost:1080"
+  parts = http.ParsedUri_.parse_ "localhost:1080" --default_scheme="https"
   expect_equals "https"     parts.scheme
   expect_equals "localhost" parts.host
   expect_equals 1080        parts.port
@@ -58,7 +58,7 @@ main:
   expect_equals null        parts.fragment
   expect                    parts.use_tls
 
-  parts = http.ParsedUri_.parse "127.0.0.1:1080"
+  parts = http.ParsedUri_.parse_ "127.0.0.1:1080" --default_scheme="https"
   expect_equals "https"     parts.scheme
   expect_equals "127.0.0.1" parts.host
   expect_equals 1080        parts.port
@@ -66,7 +66,7 @@ main:
   expect_equals null        parts.fragment
   expect                    parts.use_tls
 
-  parts = http.ParsedUri_.parse "http://localhost:1080/"
+  parts = http.ParsedUri_.parse_ "http://localhost:1080/"
   expect_equals "http"      parts.scheme
   expect_equals "localhost" parts.host
   expect_equals 1080        parts.port
@@ -74,7 +74,7 @@ main:
   expect_equals null        parts.fragment
   expect_not                parts.use_tls
 
-  parts = http.ParsedUri_.parse "http://localhost:1080/#"
+  parts = http.ParsedUri_.parse_ "http://localhost:1080/#"
   expect_equals "http"      parts.scheme
   expect_equals "localhost" parts.host
   expect_equals 1080        parts.port
@@ -82,7 +82,7 @@ main:
   expect_equals ""          parts.fragment
   expect_not                parts.use_tls
 
-  parts = http.ParsedUri_.parse "http://localhost:1080/#x"
+  parts = http.ParsedUri_.parse_ "http://localhost:1080/#x"
   expect_equals "http"      parts.scheme
   expect_equals "localhost" parts.host
   expect_equals 1080        parts.port
@@ -90,7 +90,7 @@ main:
   expect_equals "x"         parts.fragment
   expect_not                parts.use_tls
 
-  parts = http.ParsedUri_.parse "ws://xn--us--um5a.com/schneemann"
+  parts = http.ParsedUri_.parse_ "ws://xn--us--um5a.com/schneemann"
   expect_equals "ws"               parts.scheme
   expect_equals "xn--us--um5a.com" parts.host
   expect_equals 80                 parts.port
@@ -98,7 +98,7 @@ main:
   expect_equals null               parts.fragment
   expect_not                       parts.use_tls
 
-  parts = http.ParsedUri_.parse "//127.0.0.1/path"
+  parts = http.ParsedUri_.parse_ "//127.0.0.1/path" --default_scheme="https"
   expect_equals "https"            parts.scheme
   expect_equals "127.0.0.1"        parts.host
   expect_equals 443                parts.port
@@ -106,7 +106,7 @@ main:
   expect_equals null               parts.fragment
   expect                           parts.use_tls
 
-  parts = http.ParsedUri_.parse "http://127.0.0.1/path"
+  parts = http.ParsedUri_.parse_ "http://127.0.0.1/path"
   expect_equals "http"             parts.scheme
   expect_equals "127.0.0.1"        parts.host
   expect_equals 80                 parts.port
@@ -114,7 +114,7 @@ main:
   expect_equals null               parts.fragment
   expect_not                       parts.use_tls
 
-  parts = http.ParsedUri_.parse "https://original.com/foo#fraggy"
+  parts = http.ParsedUri_.parse_ "https://original.com/foo#fraggy"
   expect_equals "https"            parts.scheme
   expect_equals "original.com"     parts.host
   expect_equals 443                parts.port
@@ -122,7 +122,7 @@ main:
   expect_equals "fraggy"           parts.fragment
   expect                           parts.use_tls
 
-  parts = http.ParsedUri_.parse --previous=parts "http://redirect.com/bar"
+  parts = http.ParsedUri_.parse_ --previous=parts "http://redirect.com/bar"
   expect_equals "http"             parts.scheme  // Changed in accordance with redirect.
   expect_equals "redirect.com"     parts.host
   expect_equals 80                 parts.port
@@ -131,4 +131,4 @@ main:
   expect_not                       parts.use_tls
 
   // Can't redirect an HTTP connection to a WebSockets connection.
-  expect_throw "INVALID_REDIRECT": parts = http.ParsedUri_.parse --previous=parts "wss://socket.redirect.com/api"
+  expect_throw "INVALID_REDIRECT": parts = http.ParsedUri_.parse_ --previous=parts "wss://socket.redirect.com/api"

--- a/tests/websocket_standalone_test.toit
+++ b/tests/websocket_standalone_test.toit
@@ -18,7 +18,7 @@ main:
 run_client network port/int -> none:
   client := http.Client network
 
-  web_socket := client.web_socket "localhost" --port=port "/"
+  web_socket := client.web_socket --host="localhost" --port=port --path="/"
 
   task:: client_reading web_socket
 


### PR DESCRIPTION
The aim is that all methods take --uri for a parseable URI, but they also take --scheme, --host, --port, --path, and --fragment for a pre-parsed location.

The methods that don't fit this scheme and take unnamed arguments are marked as disappearing in the next major release, but it hardly seems worth deprecating them now.

This is not backwards compatible for those that already started using the web_socket methods, but it is thought that nobody has been so fast.

Removes the error handling block for the web_socket call, which did not fit well with the other methods and was not terribly useful.