### PR TITLE
Throw more reliably for multiple requests on client.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,13 @@ jobs:
           docker ps
           cmake -DENABLE_HTTPBIN_TESTS=ON -DUSE_HTTPBIN_DOCKER=ON build
 
+      # httpbin.org is overloaded at the moment, so if we are not running our
+      # own in Docker, don't run it at all.
+      - name: Enable httpbin tests - non-Linux
+        if: runner.os != 'Linux'
+        run: |
+          cmake -DENABLE_HTTPBIN_TESTS=OFF build
+
       - name: Install packages
         run: |
           make install-pkgs

--- a/src/connection.toit
+++ b/src/connection.toit
@@ -109,6 +109,8 @@ class Connection:
       if not headers.matches "Connection" "upgrade":
         headers.set "Content-Length" "0"
 
+    // Set this before doing blocking operations on the socket, so that we
+    // don't let another task start another request on the same connection.
     current_writer_ = body_writer
 
     socket_.set_no_delay false

--- a/src/connection.toit
+++ b/src/connection.toit
@@ -109,6 +109,8 @@ class Connection:
       if not headers.matches "Connection" "upgrade":
         headers.set "Content-Length" "0"
 
+    current_writer_ = body_writer
+
     socket_.set_no_delay false
 
     writer_.write status
@@ -120,7 +122,6 @@ class Connection:
     writer_.write "\r\n"
 
     socket_.set_no_delay true
-    current_writer_ = body_writer
     return body_writer
 
   // Gets the next request from the client. If the client closes the

--- a/tests/redirect_test_httpbin.toit
+++ b/tests/redirect_test_httpbin.toit
@@ -125,7 +125,7 @@ main args:
     else:
       HOST = host_port
 
-  if HOST = "httpbin.org":
+  if HOST == "httpbin.org":
     print "May timeout if httpbin is overloaded."
 
   network := net.open

--- a/tests/redirect_test_httpbin.toit
+++ b/tests/redirect_test_httpbin.toit
@@ -126,7 +126,7 @@ main args:
       HOST = host_port
 
   if HOST = "httpbin.org":
-    print "May timeout if httpbin is overloaded.
+    print "May timeout if httpbin is overloaded."
 
   network := net.open
 

--- a/tests/redirect_test_httpbin.toit
+++ b/tests/redirect_test_httpbin.toit
@@ -125,6 +125,9 @@ main args:
     else:
       HOST = host_port
 
+  if HOST = "httpbin.org":
+    print "May timeout if httpbin is overloaded.
+
   network := net.open
 
   test_get network


### PR DESCRIPTION
Sets the current_writer_ at an earlier point so that we detect multiple tasks trying to write requests on the same client more reliably.